### PR TITLE
Allow RubyGems to link to homepage & source code

### DIFF
--- a/jsonapi_suite.gemspec
+++ b/jsonapi_suite.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = JsonapiSuite::VERSION
   spec.authors       = ["Lee Richmond"]
   spec.email         = ["lrichmond1@bloomberg.net"]
+  spec.homepage      = "https://jsonapi-suite.github.io/jsonapi_suite_deprecated"
 
   spec.summary       = %q{Collection of gems for jsonapi.org-compatible APIs}
   spec.description   = %q{Handles automatic swagger documentation, error handling, serialization, etc}
@@ -17,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  
+  if spec.respond_to?(:metadata)
+    spec.metadata["homepage_uri"] = spec.homepage
+    spec.metadata["source_code_uri"] = "https://github.com/jsonapi-suite/jsonapi_suite_deprecated"
+  end
 
   spec.add_dependency 'actionpack', ['>= 4.1', '< 6']
   spec.add_dependency 'activesupport', ['>= 4.1', '< 6']


### PR DESCRIPTION
Currently it's insanely difficult to find the source code repository for 
jsonapi_suite looking at [rubygems.org][1] because the repo was renamed (but not the gem) and the old site is broken unless you specifically go to https://jsonapi-suite.github.io/jsonapi_suite_deprecated. 

I'd recommend publishing a 0.7.1 patch release just with this gemspec 
change so people can find the source repository and homepage and 
potentially fork jsonapi_suite to allow for Rails 6 if they can't move to 
graphiti right away for some reason. 

I'm guessing it may not be possible to loosen the version requirement 
on actionpack and activesupport but hopefully it is. 

[1]: https://rubygems.org/gems/jsonapi_suite/versions/0.7.0